### PR TITLE
container: redo readiness checks during tests

### DIFF
--- a/container/pom.xml
+++ b/container/pom.xml
@@ -44,13 +44,6 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-        
-        <dependency>
-    		<groupId>org.eclipse.parsson</groupId>
-    		<artifactId>parsson</artifactId>
-    		<version>1.1.4</version>
-    		<scope>test</scope>
-		</dependency>
 
     </dependencies>
 
@@ -74,7 +67,7 @@
 	                            <wait>
 									<time>180000</time> <!-- 3 minutes -->
 									<http>
-										<url>http://localhost:${http.port}/content/pospai/home/welcome.html</url>
+										<url>http://localhost:${http.port}/system/health.txt?tags=bundles,systemalive</url>
 										<status>200</status>
 									</http>
 								</wait>

--- a/container/src/test/java/nu/muntea/pospai/container/SmokeIT.java
+++ b/container/src/test/java/nu/muntea/pospai/container/SmokeIT.java
@@ -1,38 +1,22 @@
 package nu.muntea.pospai.container;
 
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.Authenticator;
-import java.net.PasswordAuthentication;
 import java.net.URI;
 import java.net.http.HttpClient;
-import java.net.http.HttpClient.Redirect;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.List;
 
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
-import jakarta.json.Json;
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonValue;
-
 public class SmokeIT {
 	
 	@Test
-	public void ensureConsoleIsAccessible() throws IOException, InterruptedException {
-		
-		String authPayload = Base64.getEncoder().encodeToString("admin:admin".getBytes(StandardCharsets.UTF_8));
+	public void ensurePageIsAccessible() throws IOException, InterruptedException {
 		
 		var httpClient = HttpClient.newHttpClient();
 		
@@ -41,29 +25,11 @@ public class SmokeIT {
 			port = "8080";
 		
 		var consoleRequest = HttpRequest.newBuilder()
-			.header("Authorization", "Basic " + authPayload)
-			.uri(URI.create("http://localhost:" + port + "/system/console/bundles.json")).build();
+			.uri(URI.create("http://localhost:" + port + "/content/pospai/home/welcome.html")).build();
 		
 		HttpResponse<InputStream> bundleStatus = httpClient.send(consoleRequest, BodyHandlers.ofInputStream());
 		
-		assertThat("bundles.json status code", bundleStatus.statusCode(), CoreMatchers.is(200));
-		
-		List<String> problematicBundles = new ArrayList<>();
-		try ( var parser = Json.createReader(bundleStatus.body()) ) {
-			JsonObject root = parser.readObject();
-			JsonArray bundles = root.getJsonArray("data");
-			for ( JsonValue bundle : bundles ) {
-				String bundleSymbolicName = bundle.asJsonObject().getString("symbolicName");
-				String state = bundle.asJsonObject().getString("state");
-				
-				if ( ! "Active".equals(state) && ! "Fragment".equals(state) ) {
-					problematicBundles.add(bundleSymbolicName + " is in unexpected state '" + state); 
-				}
-			}
-		}
-		
-		if ( ! problematicBundles.isEmpty() )
-			fail(problematicBundles.toString());
+		assertThat("welcome page status code", bundleStatus.statusCode(), CoreMatchers.is(200));
 	}
 
 }


### PR DESCRIPTION
- use the /system/health endpoint when waiting for startup
- check the main application page in the SmokeIT