### PR TITLE
launcher: more startup test fixes

### DIFF
--- a/container/pom.xml
+++ b/container/pom.xml
@@ -74,7 +74,7 @@
 	                            <wait>
 									<time>${docker.start.wait.time}</time>
 									<http>
-										<url>http://localhost:${http.port}/system/health.txt?tags=bundles,systemalive</url>
+										<url>http://localhost:${http.port}/system/health.txt?tags=bundles,systemalive,content</url>
 										<status>200</status>
 									</http>
 								</wait>

--- a/container/src/test/java/nu/muntea/pospai/container/SmokeIT.java
+++ b/container/src/test/java/nu/muntea/pospai/container/SmokeIT.java
@@ -21,7 +21,7 @@ public class SmokeIT {
 		
 		String port = System.getenv("HTTP_PORT") != null ? System.getenv("HTTP_PORT") : "8080";
 		
-		await().atMost(30, SECONDS).until(() -> {
+		await().atMost(180, SECONDS).until(() -> {
 			var consoleRequest = HttpRequest.newBuilder()
 					.uri(URI.create("http://localhost:" + port + "/content/pospai/home/welcome.html")).build();
 				

--- a/launcher/src/main/features/launcher.json
+++ b/launcher/src/main/features/launcher.json
@@ -42,7 +42,18 @@
             "user.mapping":[
                 "nu.muntea.pospai.core:avatar=[home-reader-service]"
             ]
-        }  
+        },
+    "org.apache.felix.hc.generalchecks.HttpRequestsCheck~pages":    {
+      "hc.tags":[
+        "content"
+      ],
+      "hc.name":"Well-known request paths return expected HTTP status",
+      "hc.mbean.name":"Initial content requests",
+      "requests":[
+        "/content/pospai/home/welcome.html => 200 && MATCHES <title>pospai.*</title>",
+        "/bin/browser.html => 401"
+      ]
+    }
   },
   "repoinit:TEXT|true":"@file"
 }


### PR DESCRIPTION
- create a 'pages' health check
- allow for a longer timeout in the SmokeIT