### PR TITLE
container: switch to temurin

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,5 +1,5 @@
 FROM docker.io/apache/sling:snapshot AS starter
-FROM docker.io/openjdk:17-slim
+FROM docker.io/eclipse-temurin:17
 
 EXPOSE 8080
 


### PR DESCRIPTION
The openjdk container images are deprecated and not kept up-to-date.