### PR TITLE
chore(rpm): set SuccessExitStatus in the systemd service file

### DIFF
--- a/rpm/src/main/resources/systemd/pospai.service
+++ b/rpm/src/main/resources/systemd/pospai.service
@@ -7,6 +7,7 @@ User=pospai
 WorkingDirectory=~
 Environment=APP_HOME=/usr/share/pospai
 ExecStart=/usr/share/pospai/bin/pospai-systemd.sh
+SuccessExitStatus=143
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This is the expected exit code and we need to inform systemd about this so that it does not mark the service as failed on regular exit.