### PR TITLE
Revert "chore(deps): update dependency org.apache.felix:org.apache.felix.healthcheck.core to v2.2.0 (#64)"

### DIFF
--- a/launcher/src/main/features/platform/healthcheck.json
+++ b/launcher/src/main/features/platform/healthcheck.json
@@ -6,7 +6,7 @@
             "start-order":"5"
         },
         {
-            "id":"org.apache.felix:org.apache.felix.healthcheck.core:2.2.0",
+            "id":"org.apache.felix:org.apache.felix.healthcheck.core:2.0.14",
             "start-order":"5"
         },
         {


### PR DESCRIPTION
This reverts commit fd85aff3c517cc73f052df158fb79d768d49de77.

This change has broken health checks, with the /system/health.txt endpoint being served briefly during startup by the HealthCheck servlet, and then being taken over by Sling.