### PR TITLE
chore(renovate): extend config:recommended instead of config:base

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:recommended",
     "regexManagers:mavenPropertyVersions"
   ],
   "ignorePresets": [


### PR DESCRIPTION
This should finally enable the Java LTS versions workaround.