### PR TITLE
fix: specify a servlet contextg for the HealthCheck servlet

### DIFF
--- a/launcher/src/main/features/platform/healthcheck.json
+++ b/launcher/src/main/features/platform/healthcheck.json
@@ -53,7 +53,8 @@
             ]
         },
         "org.apache.felix.hc.core.impl.servlet.HealthCheckExecutorServlet~default":{
-            "servletPath":"/system/health"
+            "servletPath":"/system/health",
+	        "servletContextName":"org.osgi.service.http"
         },
         "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~hc-support":{
             "user.mapping":[


### PR DESCRIPTION
This prevents it from being shadowed by the Sling main servlet. Backport of upstream fix https://github.com/apache/sling-org-apache-sling-starter/commit/5e559dfad84c3854032d292f105c65633afcb5e2 .